### PR TITLE
build: Ignore storefront with package `latest`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["**/storefront/**"]
 }


### PR DESCRIPTION
Our workflow currently has this issue:
![image](https://github.com/felleslosninger/tlp-organization-chart/assets/14057205/cb90cbf9-a611-4195-ba45-d9f7007abca1)

I believe ignoring the `storefront` folder might fix this